### PR TITLE
Basic認証を削除

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,16 +1,3 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth, if: :production?
-  protect_from_forgery with: :exception
 
-  private
-
-  def production?
-    Rails.env.production?
-  end
-
-  def basic_auth
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
-    end
-  end
 end


### PR DESCRIPTION
# WHAT
Basic認証を削除する

# WHY
自動デプロイする際Basic認証を再設定しないといけない為