### PR TITLE
コメント機能のエラー修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,7 @@
 class CommentsController < ApplicationController
+
+  protect_from_forgery :except => [:destroy]
+
   def create
     @comment = Comment.new(comments_params)
     if @comment.save


### PR DESCRIPTION
# What
コメント機能のエラー修正する

# Why
ログインした後すぐにコメントを削除するとエラーが起こる為