### PR TITLE
ヘッダーのマイページボックスのCSSを修正

### DIFF
--- a/app/assets/stylesheets/modules/main-header.scss
+++ b/app/assets/stylesheets/modules/main-header.scss
@@ -179,7 +179,7 @@
         &-box{
             position: absolute;
             top: 35px;
-            z-index: 1;
+            z-index: 11;
             display: none;
             width: 320px;
             background: #fff;


### PR DESCRIPTION
# What
ヘッダーのマイページボックスのCSSを修正

# Why
マイページボックスと商品画像が被ってしまう為